### PR TITLE
fix(CI/CD): Increase /dev/shm volume size of docker container

### DIFF
--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -38,7 +38,12 @@ mkdir -p fabric8-ui-dist
 docker build -t fabric8-planner-builder -f Dockerfile .
 # User root is required to run webdriver-manager update.
 # This shouldn't be a problem for CI containers
-CID=$(docker run --detach=true -v $(pwd)/fabric8-ui-dist:/home/fabric8/fabric8-planner/fabric8-ui-dist:Z --cap-add=SYS_ADMIN -t fabric8-planner-builder)
+# Chrome crashed on low size of /dev/shm. We need the --shm-size=256m flag.
+CID=$(docker run --detach=true \
+    --shm-size=256m \
+    -v $(pwd)/fabric8-ui-dist:/home/fabric8/fabric8-planner/fabric8-ui-dist:Z \
+    --cap-add=SYS_ADMIN \
+    -t fabric8-planner-builder)
 
 
 # Build fabric8-planner


### PR DESCRIPTION
Funtional tests always fail on ci.centos.org due to low size of /dev/shm volume of the container in which the tests run. This is a known issue with running selenium (protractor) inside docker container. More info - https://github.com/elgalu/docker-selenium/issues/20#issuecomment-133011186