### PR TITLE
fix(CI/CD): Fall back to webdriver version 2.33

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -11,8 +11,8 @@
   "license": "Apache 2",
   "scripts": {
     "tsc": "tsc",
-    "webdriver:update": "webdriver-manager update --versions.chrome",
-    "webdriver:start": "webdriver-manager start --versions.chrome",
+    "webdriver:update": "webdriver-manager update --versions.chrome 2.33",
+    "webdriver:start": "webdriver-manager start --versions.chrome 2.33",
     "protractor": "protractor tmp/protractor.conf.js",
     "test": "./run.sh"
   },

--- a/tests/package.json
+++ b/tests/package.json
@@ -11,8 +11,8 @@
   "license": "Apache 2",
   "scripts": {
     "tsc": "tsc",
-    "webdriver:update": "webdriver-manager update",
-    "webdriver:start": "webdriver-manager start",
+    "webdriver:update": "webdriver-manager update --versions.chrome",
+    "webdriver:start": "webdriver-manager start --versions.chrome",
     "protractor": "protractor tmp/protractor.conf.js",
     "test": "./run.sh"
   },


### PR DESCRIPTION
The CICO builds are failed with `Required version` exception. 
Reverting back to version 2.33.